### PR TITLE
修复部分元素点击时报错的问题

### DIFF
--- a/pyse/pyse.py
+++ b/pyse/pyse.py
@@ -150,13 +150,11 @@ class Pyse(object):
         Usage:
         driver.click("css=>#el")
         '''
+        self.element_wait(css)
+        el = self.get_element(css)
         try:
-            self.element_wait(css)
-            el = self.get_element(css)
             el.click()
         except Exception as e:
-            self.element_wait(css)
-            el = self.get_element(css)
             self.move_to_element(el)
             ActionChains(self.driver).click().perform()
 

--- a/pyse/pyse.py
+++ b/pyse/pyse.py
@@ -150,9 +150,15 @@ class Pyse(object):
         Usage:
         driver.click("css=>#el")
         '''
-        self.element_wait(css)
-        el = self.get_element(css)
-        el.click()
+        try:
+            self.element_wait(css)
+            el = self.get_element(css)
+            el.click()
+        except Exception as e:
+            self.element_wait(css)
+            el = self.get_element(css)
+            self.move_to_element(el)
+            ActionChains(self.driver).click().perform()
 
     def right_click(self, css):
         '''


### PR DESCRIPTION
raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: unknown error: Element <a href="#">...</a> is not clickable at point (981, 839). Other element would receive the click: <div class="blockUI blockOverlay" style="z-index: 2147483647; border: none; margin: 0px; padding: 0px; width: 100%; height: 100%; top: 0px; left: 0px; background-color: rgb(219, 219, 219); opacity: 0.0269615; cursor: default; position: fixed;"></div>