### PR TITLE
fix unreadable code in Windows console

### DIFF
--- a/seldom/logging/log.py
+++ b/seldom/logging/log.py
@@ -6,6 +6,8 @@ import platform
 import logging.handlers
 from colorama import Fore, Style
 
+os.system('')
+
 __all__ = [
     "debug", "info", "error", "warn", "_print",
     "set_level", "set_level_to_debug", "set_level_to_info", "set_level_to_warn", "set_level_to_error"


### PR DESCRIPTION
When running the run.py in the test project, the log information in the Windows **Pycharm** terminal or **cmd** console will not show color output but starting with strange charaters such as ←[32m at the front. This is because it simply outputs the ASCII Escape character (\033) and the color( e.g. [32m is green). We can add `os.system('')` to identify the color of output.

Notice that Linux or Mac do not has this problem. But there is no side effect to have this line of code on Linux or Mac.
