### PR TITLE
main函数中增加device参数，用于seldom使用uiautomator2时候，可结合Pool进程池实现多设备并发执行，提升测效。

### DIFF
--- a/seldom/case.py
+++ b/seldom/case.py
@@ -91,6 +91,13 @@ class TestCase(unittest.TestCase, AppDriver, HttpRequest):
         """
         return Seldom.driver
 
+    @property
+    def device(self):
+        """
+        return uiautomator2 driver (app)
+        """
+        return Seldom.device
+    
     def browser(self, name: str) -> None:
         """
         launch browser.

--- a/seldom/running/config.py
+++ b/seldom/running/config.py
@@ -33,7 +33,18 @@ class Seldom:
     @base_url.setter
     def base_url(self, value):
         self._thread_local.base_url = value
+    
+    @property
+    def device(self):
+        """
+        Android base device
+        """
+        return getattr(self._thread_local, 'device', None)
 
+    @device.setter
+    def device(self, value):
+        self._thread_local.device = value
+    
     timeout = 10
     debug = False
     compare_url = None

--- a/seldom/running/runner.py
+++ b/seldom/running/runner.py
@@ -229,7 +229,7 @@ class TestMain:
                     runner.run(suits)
                 else:
                     is_local = report_local_style()
-                    runner = HTMLTestRunner(stream=fp, title=self.title, tester=self.tester,
+                    runner = HTMLTestRunner(stream=fp, title=self.title + " For " + self.device, tester=self.tester,
                                             description=self.description, local_style=is_local,
                                             rerun=self.rerun, logger=log_cfg,
                                             language=self.language, blacklist=self.blacklist, whitelist=self.whitelist)

--- a/seldom/running/runner.py
+++ b/seldom/running/runner.py
@@ -75,7 +75,8 @@ class TestMain:
             extensions: Optional = None,
             failfast: bool = False,
             env: str = None,
-            benchmark: bool = False
+            benchmark: bool = False,
+            device: str = None
     ):
         """
         runner test case
@@ -101,6 +102,7 @@ class TestMain:
         :parma failfast: only support debug=True
         :parma env:
         :parma benchmark:
+        :parma device:
         :return:
         """
         print(SELDOM_STR)
@@ -119,6 +121,7 @@ class TestMain:
         self.open = open
         self.auto = auto
         self.failfast = failfast
+        self.device = device
         Seldom.app_server = app_server
         Seldom.app_info = app_info
         Seldom.extensions = extensions


### PR DESCRIPTION
main函数中增加device参数，用于seldom使用uiautomator2时候，可结合Pool进程池实现多设备并发执行，提升测效。
