### PR TITLE
loader("start_run")和loader("end_run")在cli.py和runner.py的run_cases()、main()方法中有重复，建议cli.py中的去掉

### DIFF
--- a/seldom/cli.py
+++ b/seldom/cli.py
@@ -202,7 +202,7 @@ def main(
             typer.echo(f"Add Env Path: {os.path.dirname(path)}.")
             file.add_to_path(os.path.dirname(path))
 
-            loader("start_run")
+            # loader("start_run")
             with open(case_json, encoding="utf-8") as json_file:
                 case = json.load(json_file)
                 path, case = reset_case(path, case)
@@ -212,28 +212,28 @@ def main(
                     description=description, rerun=rerun, language=language,
                     whitelist=whitelist, blacklist=blacklist, extensions=extensions)
                 main_extend.run_cases(case)
-            loader("end_run")
+            # loader("end_run")
             return 0
 
-        loader("start_run")
+        # loader("start_run")
         seldom.main(
             path=path, browser=browser, base_url=base_url, debug=debug, timeout=timeout,
             app_server=app_server, app_info=app_info, report=report, title=title, tester=tester,
             description=description, rerun=rerun, language=language,
             whitelist=whitelist, blacklist=blacklist, extensions=extensions, failfast=failfast)
-        loader("end_run")
+        # loader("end_run")
         return 0
 
     if mod:
         file_dir = os.getcwd()
         sys.path.insert(0, file_dir)
-        loader("start_run")
+        # loader("start_run")
         seldom.main(
             case=mod, browser=browser, base_url=base_url, debug=debug, timeout=timeout,
             app_server=app_server, app_info=app_info, report=report, title=title, tester=tester,
             description=description, rerun=rerun, language=language,
             whitelist=whitelist, blacklist=blacklist, extensions=extensions, failfast=failfast)
-        loader("end_run")
+        # loader("end_run")
         return 0
 
     if har2case:
@@ -256,12 +256,12 @@ def main(
         FileRunningConfig = _import_file_running_config()
         FileRunningConfig.api_excel_file_name = api_excel
         script_path = file.join(file.dir, "file_runner", "api_excel.py")
-        loader("start_run")
+        # loader("start_run")
         seldom.main(
             path=script_path, base_url=base_url, debug=debug, timeout=timeout,
             report=report, title=title, tester=tester,
             description=description, rerun=rerun, language=language, failfast=failfast)
-        loader("end_run")
+        # loader("end_run")
         return 0
 
     return 0

--- a/seldom/extend_lib/base_assert.py
+++ b/seldom/extend_lib/base_assert.py
@@ -21,7 +21,8 @@ def log_assertions(func):
         if args:
             args_to_log = args[1:]
 
-        log.info(f"👀 {func.__name__}  -> {args_to_log}")
+        if func.__name__ != "assertIsInstance":
+            log.info(f"👀 {func.__name__}  -> {args_to_log}")
         result = func(*args, **kwargs)
         return result
 

--- a/seldom/running/runner.py
+++ b/seldom/running/runner.py
@@ -410,6 +410,7 @@ class TestMainExtend(TestMain):
         :param data: test case list
         :return:
         """
+        loader("start_run")
         if isinstance(data, list) is False:
             raise TypeError("Use cases must be lists.")
 

--- a/seldom/utils/send_extend.py
+++ b/seldom/utils/send_extend.py
@@ -16,7 +16,7 @@ from seldom.utils import file
 class SMTP(XSMTP):
     """send email class"""
 
-    def sendmail(self, to: [str, list], subject: str = None, attachments: str = None, delete: bool = False) -> None:
+    def sendmail(self, to: str | list[str], subject: str = None, attachments: str = None, delete: bool = False) -> None:
         """
         seldom send email
         :param to:


### PR DESCRIPTION
base_assert.py:避免self.assertTrue时出现多余日志打印。
send_extend.py:规范参数多类型，避免警告提示。
runner.py:run_cases()方法执行起始需加载loader("start_run")。 
cli.py:注释掉loader("start_run")和loader("end_run")，因为run_cases()和main()中已加载。